### PR TITLE
Correct retrieval of "token" flag value

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func doCreateCommand(c *cli.Context) {
 
 func getGitHubToken(c *cli.Context) string {
 	if v := c.GlobalString("token"); v != "" {
-		return c.GlobalString(v)
+		return v
 	}
 
 	if v := c.GlobalString("token-file"); v != "" {


### PR DESCRIPTION
When a caller supplies a nonempty value for the "token" flag, function `getGitHubToken` would mistakenly look up the value of another (usually) absent flag named by the "token" flag's value, instead of returning the "token" flag's value itself.

That is, given an invocation like

>  _label-all-the-things --token xxx create ..._

then instead of using "xxx" as the GitHub API token, the program would instead look for the value of a flag named "xxx".

Fixes #1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/icecrime/label-all-the-things/2)
<!-- Reviewable:end -->
